### PR TITLE
Fixed email template bugs, added to guidelines page, and implemented export event emails

### DIFF
--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -173,6 +173,7 @@ def edit_confirmation():
     ), 200
 
 
+
 @public.route("/export/<eventid>", methods=["POST"])
 def export_event(eventid):
     event_data = db.get_one(ObjectId(eventid))

--- a/modules/db.py
+++ b/modules/db.py
@@ -86,6 +86,16 @@ class DatabaseClient(object):
         form["_id"] = event_id
         return form
 
+    def add_to_export_list(self, event_id, email):
+        self.client.events.update_one(
+            {
+                "_id":ObjectId(event_id)
+            },
+            {
+                "$addToSet": {"shared_emails" : email}
+            }
+        )
+
     def delete(self, event_id):
         self.client.delete_one({
             "_id": event_id

--- a/modules/sg_client.py
+++ b/modules/sg_client.py
@@ -1,18 +1,19 @@
 import os
 import base64
+from icalendar import Calendar, Event
+from datetime import datetime
 from bson.objectid import ObjectId
 from jinja2 import Template
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import (
     Mail,
-    Email,
-    To,
-    Content, 
+    Email, 
     Attachment, 
     FileContent, 
     FileName, 
     FileType, 
-    Disposition
+    Disposition,
+    Personalization
 )
 
 class EmailClient(object):
@@ -24,13 +25,25 @@ class EmailClient(object):
         return self._client
 
     
-    def send_email(self, recipient, subject, message, attachments=None):
+    def send_email(self, subject, message, recipient, attachments=None, ismultiple=False):
             mail = Mail(
-                Email("frankscalendar.olin@gmail.com"),
-                To(recipient),
-                subject,
-                Content("text/html", message), 
-            )
+                from_email="frankscalendar.olin@gmail.com",
+                html_content=message, 
+                subject=subject,     
+                )
+
+            personalize = Personalization()
+            
+            if ismultiple:
+                for email in recipient:
+                    #add_bcc isn't working right now, and there doesn't seem to be a straightforward workaround
+                    #will now work if any of the emails in recipient list is invalid
+                    personalize.add_to(Email(email))
+            else:
+                personalize.add_to(Email(recipient))
+
+            mail.add_personalization(personalize)
+
             if attachments:
                 encoded_file = base64.b64encode(attachments).decode()
                 attachedFile = Attachment(
@@ -46,12 +59,22 @@ class EmailClient(object):
             except Exception as e:
                 print(e.message)
 
-    def send_ical(self, attachment, recipient):
-            path = os.getcwd() + "/templates/emails/export.txt"
-            template = Template(open(path).read())
-            content = template.render()
+    def send_ical(self, event_data, recipient):
+        attachment = self.create_ical(event_data)
+        path = os.getcwd() + "/templates/emails/export.txt"
+        template = Template(open(path).read())
+        content = template.render()
 
-            self.send_email(recipient, "Requested ical", content, attachment)
+        self.send_email("Requested ical", content, recipient, attachment)
+
+    def notify_shared_emails(self, event, recipients):
+        #notifies everyone who exported this event that details have been changed
+        attachment = self.create_ical(event)
+        eventname = event['title']
+        path = os.getcwd() + "/templates/emails/notify_shared_emails.txt"
+        template = Template(open(path).read())
+        content = template.render(name = eventname)
+        self.send_email("An event you added to your calendar has changed", content, recipients, attachment, True)
 
 
     def send_edit_link(self, url, event, comments):
@@ -63,7 +86,7 @@ class EmailClient(object):
         template = Template(open(path).read())
         content = template.render(name=eventname, reasons=comments, link=eventlink)
 
-        self.send_email(recipient, "Edits required for your event", content) 
+        self.send_email("Edits required for your event", content, recipient) 
 
     def send_submission_confirmation(self, url, event):
         #if user submits event via form, send confirmation of submission
@@ -75,7 +98,7 @@ class EmailClient(object):
         template = Template(open(path).read())
         content = template.render(name=eventname, link=eventlink)
 
-        self.send_email(recipient, "Event submission awaiting approval", content) 
+        self.send_email("Event submission awaiting approval", content, recipient ) 
 
     def send_reminder(self, url, event):
         #if user hasn't made requested edits, send reminder
@@ -87,7 +110,7 @@ class EmailClient(object):
         template = Template(open(path).read())
         content = template.render(name=eventname, link=eventlink)
 
-        self.send_email(recipient, "Reminder to make requested edits!", content) 
+        self.send_email("Reminder to make requested edits!", content, recipient) 
 
     def send_approval_notice(self, url, event):
         #if event was approved by moderator, send notice
@@ -99,7 +122,7 @@ class EmailClient(object):
         template = Template(open(path).read())
         content = template.render(name=eventname, link=eventlink)
 
-        self.send_email(recipient, "Event submission approved!", content) 
+        self.send_email("Event submission approved!", content, recipient) 
 
     def notify_moderator(self, url, event, moderator):
         #if event was modified after the moderator already approved it, an email will notify the moderator of changes
@@ -119,11 +142,24 @@ class EmailClient(object):
             host=event['host_name'], 
             host_email=event['host_email'])
         
-        self.send_email(recipient, "A published event was updated", content) 
+        self.send_email("A published event was updated", content, recipient) 
 
     def generate_link(self, base, event):
         magic = str(event['magic'])
         eventid = str(event['_id'])
         #issues with retrieving base right now, but should be resolved when we have permanent hosting solution
         #return base + "/edit?event_id=" + eventid + "&magic=" + magic   
-        return "64.227.7.192:5000/edit/" + eventid + "?magic=" + magic    
+        return "calendar.olin.build:5000/edit/" + eventid + "?magic=" + magic 
+
+    def create_ical(self, eventdata):
+        #moved this method here from the public file bc we need to generate an ical multiple times
+        cal = Calendar()
+        event = Event()
+        event["dtstart"] = datetime.strftime(eventdata["dtstart"], "%Y%m%dT%H%M%S")
+        event["dtend"] = datetime.strftime(eventdata["dtend"], "%Y%m%dT%H%M%S")
+        event["summary"] = eventdata["title"]
+        event["location"] = eventdata["location"]
+        event["description"] = eventdata["description"]
+        cal.add_component(event)
+
+        return cal.to_ical()

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -22,7 +22,7 @@
                 <td class="Submitter"><a href="mailto:{{ event['host_email'] }}">{{ event["host_name"] }}</a></td>
                 <td class="Status" data-status={{ event["status"] }}>{{ event["status"] }}</td>
                 <td class="Event--Name">{{ event["title"] }}</td>
-                <td class="Event--Page"><a href="/">Event Page Permalink</a></td>
+                <td class="Event--Page"><a href="/#{{event['_id']}}">Event Page Permalink</a></td>
                 <td class="Edit--Link"><a href="/edit/{{ event['_id'] }}?magic={{ event['magic'] }}">Edit Page Permalink</a></td>
                 <td class="Cell--Moderator">
                     <a href="/approve/{{ event['_id'] }}?magic={{ event['magic'] }}" class="Moderator Moderator--approve">Approve</a>

--- a/templates/emails/approved.txt
+++ b/templates/emails/approved.txt
@@ -1,6 +1,6 @@
 Hi!
-
+<br><br>
 The event you submitted, {{name}}, was approved and is currently posted on Frank’s Calendar! As a reminder, if any event information needs to be updated, you can do so via this <a href=http://{{link}}>magic link</a>, which is active up until the start time of your event.
-
-Sincerely, 
+<br><br>
+Sincerely, <br>
 Frank's Calendar

--- a/templates/emails/await_approval.txt
+++ b/templates/emails/await_approval.txt
@@ -1,6 +1,6 @@
 Hi!
 
-Your event, {{name}} was successfully submitted for review, and is awaiting moderator approval. We will send you a notice within 24 hours, as soon it has been reviewed. In the meantime, you may make edits to your event via this <a href=http://{{link}}>magic link</a> if any information changes.
+Your event, {{name}} was successfully submitted for review, and is awaiting moderator approval. We will send you a notice within 24 hours, as soon it has been reviewed. In the meantime, you may make edits to your event via this <a href={{link}}>magic link</a> if any information changes.
 
 Sincerely, 
 Frank's Calendar

--- a/templates/emails/await_approval.txt
+++ b/templates/emails/await_approval.txt
@@ -1,6 +1,6 @@
 Hi!
 
-Your event, {{name}} was successfully submitted for review, and is awaiting moderator approval. We will send you a notice within 24 hours, as soon it has been reviewed. In the meantime, you may make edits to your event via this <a href={{link}}>magic link</a> if any information changes.
+Your event, {{name}} was successfully submitted for review, and is awaiting moderator approval. We will send you a notice within 24 hours, as soon it has been reviewed. In the meantime, you may make edits to your event via this <a href=http://{{link}}>magic link</a> if any information changes.
 
 Sincerely, 
 Frank's Calendar

--- a/templates/emails/await_approval.txt
+++ b/templates/emails/await_approval.txt
@@ -1,6 +1,6 @@
 Hi!
-
+<br><br>
 Your event, {{name}} was successfully submitted for review, and is awaiting moderator approval. We will send you a notice within 24 hours, as soon it has been reviewed. In the meantime, you may make edits to your event via this <a href=http://{{link}}>magic link</a> if any information changes.
-
-Sincerely, 
+<br><br>
+Sincerely, <br>
 Frank's Calendar

--- a/templates/emails/cancelled.txt
+++ b/templates/emails/cancelled.txt
@@ -1,8 +1,6 @@
 Hi!
-
-The event you submitted, {{name}}, was cancelled by the moderator, for the following reasons:
-
-___________.
-
-Sincerely, 
+<br><br>
+The event you submitted, {{name}}, was cancelled by the moderator, for the following reasons:___________.
+<br><br>
+Sincerely, <br>
 Frank's Calendar

--- a/templates/emails/edit_event.txt
+++ b/templates/emails/edit_event.txt
@@ -4,7 +4,7 @@ The event you submitted to Frank’s Calendar, {{name}}, requires edits before i
 
 _________
 
-Please make the required changes within 7 days via this <a href=http://{{link}}>magic link</a> .
+Please make the required changes within 7 days via this <a href={{link}}>magic link</a>.
 
 Sincerely, 
 Frank's Calendar

--- a/templates/emails/edit_event.txt
+++ b/templates/emails/edit_event.txt
@@ -4,7 +4,7 @@ The event you submitted to Frank’s Calendar, {{name}}, requires edits before i
 
 _________
 
-Please make the required changes within 7 days via this <a href={{link}}>magic link</a>.
+Please make the required changes within 7 days via this <a href=http://{{link}}>magic link</a> .
 
 Sincerely, 
 Frank's Calendar

--- a/templates/emails/edit_event.txt
+++ b/templates/emails/edit_event.txt
@@ -1,10 +1,8 @@
 Hi!
-
-The event you submitted to Frank’s Calendar, {{name}}, requires edits before it can be approved! The moderator requests the following changes: 
-
-_________
-
+<br><br>
+The event you submitted to Frank’s Calendar, {{name}}, requires edits before it can be approved! The moderator requests the following changes: _________
+<br><br>
 Please make the required changes within 7 days via this <a href=http://{{link}}>magic link</a> .
-
-Sincerely, 
+<br><br>
+Sincerely,<br>
 Frank's Calendar

--- a/templates/emails/export.txt
+++ b/templates/emails/export.txt
@@ -1,6 +1,6 @@
 Hi! 
-
+<br><br>
 Here is the ical file you requested. If any changes are made to this event, you will recieve a notifaction email. 
-
-Sincerely, 
+<br><br>
+Sincerely, <br>
 Frank's Calendar

--- a/templates/emails/notify_moderator.txt
+++ b/templates/emails/notify_moderator.txt
@@ -1,14 +1,14 @@
 Hi! 
-
+<br><br>
 Changes were made to, {{title}} today. The event information now consists of: 
-
-Title: {{title}}
-Host: {{host}}, {{host_email}}
-When: {{dtstart}} to {{dtend}}
-Where: {{location}}
+<br><br>
+Title: {{title}}<br>
+Host: {{host}}, {{host_email}}<br>
+When: {{dtstart}} to {{dtend}}<br>
+Where: {{location}}<br>
 What: {{description}}
-          
+<br><br>    
 If changes were not appropriate, cancel the event via this <a href=http://{{link}}>magic link</a> .
-
-Sincerely, 
+<br><br>
+Sincerely, <br>
 Frank's Calendar

--- a/templates/emails/notify_shared_emails.txt
+++ b/templates/emails/notify_shared_emails.txt
@@ -1,0 +1,5 @@
+Hi! <br><br>
+An event that you exported from Frank's Calendar, {{name}}, has recently been edited by its host. Here is the most updated ical of that event. 
+<br><br>
+Sincerely, <br>
+Frank's Calendar

--- a/templates/emails/reminder.txt
+++ b/templates/emails/reminder.txt
@@ -1,6 +1,6 @@
-Hi!
-
+Hi! 
+<br><br>
 You must make edits to your event, {{name}}, before it can be considered for approval. Please do so within 2 days, or it will automatically be removed from the approval process. You can make the required edits via this <a href=http://{{link}}>magic link</a> .  
-
-Sincerely, 
+<br><br>
+Sincerely, <br>
 Frank's Calendar

--- a/templates/guidelines.html
+++ b/templates/guidelines.html
@@ -27,9 +27,11 @@
                         <td class="Guidelines__table__row__data">
                             <h3 class="Guidelines__dont-belong">These don't</h3>
                             <ul class="Guidelines__minuses">
-                                <li>Events only open to a <span class="Guidelines__underline">smaller group of people</span> (e.g. club meetings only for club members, parties with your friends)</li>
+                                <li>Events only open to a <span class="Guidelines__underline">smaller group of people</span> (e.g. club meetings only for club members, ninja and arc hours, parties with your friends)</li>
                                 
                                 <li>Events hosted by <span class="Guidelines__underline">non-Oliners</span></li>
+                              
+                               
                             </ul>
 
                         </td>
@@ -44,18 +46,27 @@
             <h2 class="Guidelines__section__head">Moderator System</h2>
             <div class="Guidelines__section__content">
 
-                <p> Calendar moderators maintain the events on the calendar to guarantee that Frank’s Calendar is populated with <span class="Guidelines__underline">accurate, up to date information</span> about what is happening on campus. They also monitor events to make sure they meet the requirements of what is okay to share. </p>
-                    <p> <span class="Guidelines__underline">Their job and admin privileges include:</span></p>
+                <p> Calendar moderators maintain the events on the calendar to guarantee that Frank’s Calendar is populated with <span class="Guidelines__underline">accurate, up to date information</span> about what is happening on campus. They also monitor events to make sure they meet the requirements of what is acceptable to share. </p>
+                    <p> <span class="Guidelines__underline">Their admin privileges include:</span></p>
                     <ul>
                         <li>Reviewing event submissions</li>
                         <li>Approving, requesting changes, or cancelling an event submission</li>
-                        <li>Sharing the link to edit your event with you if you lost it</li>
+                        <li>Sharing the link to edit an event if hosts lose their link</li>
                     </ul>
+                    <p>If you're interested in becoming a moderator or developer for Frank's Calendar, please contact one of the current moderators listed below.</p>
                     <h3 class="Guidelines__mods">Current Moderators</h3>
                     <div class="Guidelines__centered">
                         <p>Jules Brettle, <a href="mailto:jbrettle@olin.edu">jbrettle@olin.edu</a></p>
+                        <p>Raquel Dunoff, <a href="mailto:raquel.dunoff@students.olin.edu">raquel.dunoff@students.olin.edu</a></p>
                     </div>
+              
                 
+            </div>
+        </div>
+        <div class="Guidelines__section">
+            <h2 class="Guidelines__section__head">Leave us Feedback</h2>
+            <div class="Guidelines__section__content">
+                <p>If you have any questions or concerns, feel free to reach out to one of the moderators, or fill out <a href="https://docs.google.com/forms/d/e/1FAIpQLSfUonGHYeGDpkSFN1oGf6_ngFS9mhIMLpZcnWC2xvdvbREx7A/viewform">this</a> google form. We will get back to you as soon as possible.</p>
 
             </div>
         </div>


### PR DESCRIPTION
Refactored some code so ical files are now made in sg_client. Added line breaks to the email templates. Added some more information to guidelines page. Fixed permalinks in admin page. When user exports an event, their email will be added to the event's "shared email" list, and if changes are ever made to that event, everyone on the list will be notified that changes were made. 